### PR TITLE
Upgrade Pillow, Django and urllib3 to patched versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==3.2.18
+Django==3.2.19
 Whoosh==2.7.4
 appdirs== 1.4.3
 beautifulsoup4
@@ -31,7 +31,7 @@ easy-thumbnails==2.8.5
 gunicorn==19.6.0
 jmespath==0.9.1
 markdown2==2.4.0
-packaging==16.8
+packaging==19.0
 pyparsing==2.2.0
 sqlparse==0.4.4
 psycopg2==2.9.* --no-binary psycopg2
@@ -43,5 +43,6 @@ s3transfer==0.7.0
 sigauth==4.3.0
 six==1.12.0
 uk-postcode-utils==1.0
-urllib3==1.26.5
+urllib3==1.26.17
 whitenoise==6.6.0
+pillow==10.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ directory-sso-api-client==6.3.0
     # via -r requirements.in
 dj-database-url==0.4.1
     # via -r requirements.in
-django==3.2.18
+django==3.2.19
     # via
     #   -r requirements.in
     #   directory-client-core
@@ -127,12 +127,14 @@ monotonic==1.6
     # via directory-client-core
 oauthlib==3.2.2
     # via requests-oauthlib
-packaging==16.8
+packaging==19.0
     # via
     #   -r requirements.in
     #   pytest
-pillow==9.3.0
-    # via easy-thumbnails
+pillow==10.0.1
+    # via
+    #   -r requirements.in
+    #   easy-thumbnails
 pluggy==1.3.0
     # via pytest
 psycopg2==2.9.9
@@ -193,7 +195,7 @@ typing-extensions==4.8.0
     # via asgiref
 uk-postcode-utils==1.0
     # via -r requirements.in
-urllib3==1.26.5
+urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -53,7 +53,7 @@ directory-sso-api-client==6.3.0
     # via -r requirements.in
 dj-database-url==0.4.1
     # via -r requirements.in
-django==3.2.18
+django==3.2.19
     # via
     #   -r requirements.in
     #   directory-client-core
@@ -141,13 +141,15 @@ more-itertools==8.4.0
     # via pytest
 oauthlib==3.2.2
     # via requests-oauthlib
-packaging==16.8
+packaging==19.0
     # via
     #   -r requirements.in
     #   pytest
     #   pytest-sugar
-pillow==9.3.0
-    # via easy-thumbnails
+pillow==10.0.1
+    # via
+    #   -r requirements.in
+    #   easy-thumbnails
 pluggy==0.13.1
     # via pytest
 psycopg2==2.9.9
@@ -234,7 +236,7 @@ typing-extensions==4.8.0
     # via asgiref
 uk-postcode-utils==1.0
     # via -r requirements.in
-urllib3==1.26.5
+urllib3==1.26.17
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
Updated package versions and compiled requirements. Sub dependancy pillow had to be updated manually as we are already on the latest version of easy-thumbnails

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1309, https://uktrade.atlassian.net/browse/KLS-1313, https://uktrade.atlassian.net/browse/KLS-1333
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] I have updated security dependencies

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
